### PR TITLE
ETD-126: open telemetry tracing calls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,9 +8,12 @@ CONSOLE_LOGGING_ONLY=false
 
 CONSUME_QUEUE_NAME=etd_submission_ready
 PUBLISH_QUEUE_NAME=etd_in_storage
-BROKER_URL+""
+BROKER_URL=""
 
 PRIVATE_KEY_PATH=
+
+JAEGER_NAME="http://localhost:4317"
+JAEGER_SERVICE_NAME=ETD
 
 instance=''
 homeDir=''

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,11 @@ certifi==2022.12.7
 coverage==7.2.6
 iniconfig==2.0.0
 lxml==4.9.2
+opentelemetry-api==1.19.0
+opentelemetry-sdk==1.19.0
+opentelemetry-exporter-jaeger==1.19.0
+opentelemetry-exporter-otlp-proto-grpc==1.19.0
+opentelemetry-semantic-conventions==0.40b0
 packaging==23.1
 pluggy==1.0.0
 project-paths==1.1.1

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -3,6 +3,14 @@ import os
 import logging
 import etd
 from etd.worker import Worker
+import json
+from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+        OTLPSpanExporter)
+from opentelemetry.sdk.resources import SERVICE_NAME
 
 app = Celery()
 app.config_from_object('celeryconfig')
@@ -12,7 +20,21 @@ logger = logging.getLogger('etd_dash')
 FEATURE_FLAGS = "feature_flags"
 DASH_FEATURE_FLAG = "dash_feature_flag"
 
+# tracing setup
+JAEGER_NAME = os.getenv('JAEGER_NAME')
+JAEGER_SERVICE_NAME = os.getenv('JAEGER_SERVICE_NAME')
 
+resource = Resource(attributes={SERVICE_NAME: JAEGER_SERVICE_NAME})
+trace.set_tracer_provider(TracerProvider(resource=resource))
+tracer = trace.get_tracer(__name__)
+
+otlp_exporter = OTLPSpanExporter(endpoint=JAEGER_NAME, insecure=True)
+
+span_processor = BatchSpanProcessor(otlp_exporter)
+trace.get_tracer_provider().add_span_processor(span_processor)
+
+
+@tracer.start_as_current_span("send_to_dash_task")
 @app.task(serializer='json', name='etd-dash-service.tasks.send_to_dash')
 def send_to_dash(json_message):
     logger.info("message")
@@ -25,6 +47,9 @@ def send_to_dash(json_message):
                 feature_flags[DASH_FEATURE_FLAG] == "on":
             # Send to DASH
             logger.debug("FEATURE IS ON>>>>>SEND TO DASH")
+            current_span = trace.get_current_span()
+            current_span.add_event("FEATURE IS ON>>>>>SEND TO DASH")
+            current_span.add_event(json.dumps(json_message))
             worker = Worker()
             msg = worker.send_to_dash(json_message)
             logger.debug(msg)
@@ -39,5 +64,6 @@ def send_to_dash(json_message):
     if "unit_test" in json_message:
         return new_message
 
+    current_span.add_event("to next queue")
     app.send_task("etd-alma-service.tasks.send_to_alma", args=[new_message],
                   kwargs={}, queue=os.getenv('PUBLISH_QUEUE_NAME'))


### PR DESCRIPTION
**ETD-126: open telemetry tracing calls*
* * *

**JIRA Ticket**: https://jira.huit.harvard.edu/browse/ETD-126


# What does this Pull Request do?
this adds tracing calls to the dash service

# How should this be tested?

first start a local version of jaeger:

` docker pull jaegertracing/all-in-one:latest`
then
`docker run -d --name jaeger \
  -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 \
  -e COLLECTOR_OTLP_ENABLED=true \
  -p 6831:6831/udp \
  -p 6832:6832/udp \
  -p 5778:5778 \
  -p 16686:16686 \
  -p 4317:4317 \
  -p 4318:4318 \
  -p 14250:14250 \
  -p 14268:14268 \
  -p 14269:14269 \
  -p 9411:9411 \
  jaegertracing/all-in-one:latest`

then set the "JAEGER_NAME" in your local .env file to "http://YOUR-LOCAL-IP:4317/"
start the container.  enter it and run `pytest`.
then go to http://localhost:16686/  .  you should see traces from the app in the dashboard.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? n
- integration tests? n

# Interested parties
Tag (@ mention) interested parties: @awoods 
