### PR TITLE
Etd 206: Trace on ProQuest ID

### DIFF
--- a/etd/worker.py
+++ b/etd/worker.py
@@ -492,6 +492,8 @@ class Worker():
                         json_message["identifier"] = proquest_identifier
                         current_span.set_attribute("identifier",
                                                    proquest_identifier)
+                        self.logger.info("proquest id: " +
+                                         str(proquest_identifier))
                     except Exception as e:  # pragma: no cover
                         self.logger.info(e)
                         current_span.record_exception(e)

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -110,6 +110,7 @@ def send_to_dash(json_message):
                     new_message['identifier'] = proquest_identifier
                     current_span.set_attribute("identifier",
                                                proquest_identifier)
+                    logger.debug("processing id: " + str(proquest_identifier))
 
             else:
                 # Feature is off so do hello world

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -105,6 +105,11 @@ def send_to_dash(json_message):
                 worker = Worker()
                 msg = worker.send_to_dash(json_message)
                 logger.debug(msg)
+                if 'identifier' in json_message:
+                    proquest_identifier = json_message['identifier']
+                    new_message['identifier'] = proquest_identifier
+                    current_span.set_attribute("identifier",
+                                               proquest_identifier)
 
             else:
                 # Feature is off so do hello world

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -11,7 +11,10 @@ class TestTasksClass():
                     'dash_feature_flag': "off",
                     'alma_feature_flag': "off",
                     'send_to_drs_feature_flag': "off",
-                    'drs_holding_record_feature_flag': "off"}}
+                    'drs_holding_record_feature_flag': "off"},
+                   "identifier": "30522803"}
         retval = tasks.send_to_dash(message)
         assert "job_ticket_id" in retval
         assert "feature_flags" in retval
+        assert "identifier" in retval
+        assert retval["identifier"] == "30522803"

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -85,7 +85,8 @@ class TestWorkerClass():
         metsBeforeFile = os.path.join(aipDir, "mets_before.xml")
         shutil.copy(metsBeforeFile, os.path.join(aipDir, "mets.xml"))
         metsFile = os.path.join(aipDir, "mets.xml")
-        worker.rewrite_mets(aipDir, batch, schoolCode)
+        json_message = {}
+        worker.rewrite_mets(aipDir, batch, schoolCode, json_message)
         # doc_before = ET.parse(os.path.join(aipDir, "mets.xml"))
         doc = ET.parse(metsFile)
 

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -115,6 +115,8 @@ class TestWorkerClass():
         assert doc.xpath("//dim:field[@qualifier='level']",
                          namespaces=namespace_mapping)[0].\
             text == "Masters"
+        
+        assert int(json_message["identfier"])== 30522803
 
         # test the exceptions with a bad mets.xml
         '''metsEmptyFile = os.path.join(aipDir, "mets_bad.xml")

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -116,7 +116,7 @@ class TestWorkerClass():
                          namespaces=namespace_mapping)[0].\
             text == "Masters"
 
-        assert int(json_message["identfier"]) == 30522803
+        assert int(json_message["identifier"]) == 30522803
 
         # test the exceptions with a bad mets.xml
         '''metsEmptyFile = os.path.join(aipDir, "mets_bad.xml")

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -115,8 +115,8 @@ class TestWorkerClass():
         assert doc.xpath("//dim:field[@qualifier='level']",
                          namespaces=namespace_mapping)[0].\
             text == "Masters"
-        
-        assert int(json_message["identfier"])== 30522803
+
+        assert int(json_message["identfier"]) == 30522803
 
         # test the exceptions with a bad mets.xml
         '''metsEmptyFile = os.path.join(aipDir, "mets_bad.xml")


### PR DESCRIPTION
**Trace on ProQuest ID**
* * *

**JIRA Ticket**: https://jira.huit.harvard.edu/browse/ETD-206

# What does this Pull Request do?
A brief description of what the intended result of the PR will be and/or what problem it solves.
Adds ProQuest ID to traces

# How should this be tested?

this has been deployed to dev.
to test on dev:
1) run the itest https://ltsds-cloud-dev-1.lib.harvard.edu:10610/integration
2) check jaeger dashboard http://ltsds-cloud-dev-1.lib.harvard.edu:16686/  then look at most recent trace and check the tags pulldown in a method. you should see "identifier = PROQUEST_ID".  you can also search for it on the dashboard on the identifier field to find methods.

to test locally:
1) run pytest unit test to validate method
or
1) set up all containers locally including itest
2) run itest locally (http://localhost:16686/)
3) check jaeger dashboard http://ltsds-cloud-dev-1.lib.harvard.edu:16686/  then look at most recent trace and check the tags pulldown in a method. you should see "identifier = PROQUEST_ID".  you can also search for it on the dashboard on the identifier field to find methods.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? y
- integration tests? y

# Interested parties
Tag (@ mention) interested parties: @awoods 
