### PR TITLE
Fix Python version issues with GitHub Actions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: [3.11.4]
+        python-version: [3.11.5]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -19,7 +19,7 @@ jobs:
         run: git checkout ${{ env.BRANCH }}
               
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
**Upgrade setup-python action and python-version.**
* * *

**JIRA Ticket**: [ETD-294](https://at-harvard.atlassian.net/browse/ETD-294)

# How should this be tested?
- Run all GitHub Actions for this branch, OR
- Take a look at the run for this commit: https://ci.lib.harvard.edu/blue/organizations/jenkins/ETD%20DASH%20Service/detail/trial/3/pipeline

# Test coverage
N/A

# Interested parties
@awoods, @ives1227, @cgoines 