### PR TITLE
Remove empty output directory for duplicate.

### DIFF
--- a/etd/worker.py
+++ b/etd/worker.py
@@ -193,9 +193,19 @@ class Worker():
                 dupe_dir = aipDir.replace('/in/', '/dupe/')
                 # append timestamp to the dupe_dir
                 dupe_dir = dupe_dir + "_" + self.get_timestamp()
-                # move the aip to the dupe_dir
-                self.rename_directory(aipDir, dupe_dir)
-                continue
+                # move the aip to the dupe_dir, catch exception
+                try:
+                    self.rename_directory(aipDir, dupe_dir)
+                except Exception as e:
+                    self.logger.error(f'Failed to move \
+                                        {aipDir} to {dupe_dir}: {e}')
+                # delete empty output directory, catch exception
+                try:
+                    os.rmdir(proquestOutDir)
+                except Exception as e:
+                    self.logger.error(f'Failed to remove \
+                                        {proquestOutDir}: {e}')
+                    continue
             collection_handle = instance_data[schoolCode]['handle']
             dashImportFile = f'{self.dspaceImportDir}/proquest/' + aipFile
 


### PR DESCRIPTION
**Clean up duplicate from output directory.**
* * *

**JIRA Ticket**: [ETD-304](https://at-harvard.atlassian.net/browse/ETD-304)

# What does this Pull Request do?
The proquest output directory is created before the duplication check is run. This PR will delete the output directory when a duplicate is detected. Also, error handling and logging of duplicate handling methods is improved.

# How should this be tested?
- Visual inspection
- Run it through Jenkins, or find the [matching run for this commit hash on the trial branch](https://ci.lib.harvard.edu/blue/organizations/jenkins/ETD%20DASH%20Service/activity/) and verify success.
- Notice that recent duplicates do not have corresponding directories in `out/`:

> [cvicary@ltsds-cloud-dev-1 etd_dash_data]$ ll -t dupe/ | more
total 332
drwxr-xr-x 2 etdadm appcommon 6144 Oct 30 12:23 proquest2023103016-5287875872-gsd_20231030162328
drwxr-xr-x 2 etdadm appcommon 6144 Oct 30 12:20 proquest2023103016-9238480671-gsd_20231030162024
drwxr-xr-x 2 etdadm appcommon 6144 Oct 30 11:52 proquest2023103015-4375217607-gsd_20231030155234

> [cvicary@ltsds-cloud-dev-1 etd_dash_data]$ ll out/ | grep 5287875872
[cvicary@ltsds-cloud-dev-1 etd_dash_data]$ ll out/ | grep 9238480671
[cvicary@ltsds-cloud-dev-1 etd_dash_data]$ ll out/ | grep 4375217607
[cvicary@ltsds-cloud-dev-1 etd_dash_data]$ 

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? Yes, in `etd-integration-tests`

# Interested parties
@ives1227, @michael-lts, @cgoines 
