### PR TITLE
ETD-281: Prepare logging for production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@ BROKER_URL=""
 
 PRIVATE_KEY_PATH=
 
-JAEGER_NAME="http://jaeger:4317"
+JAEGER_NAME="http://jaeger_dashboard:4317"
 JAEGER_SERVICE_NAME=ETD
 
 DASH_REST_URL="https://dspace6-qai.lib.harvard.edu/rest"

--- a/etd/__init__.py
+++ b/etd/__init__.py
@@ -16,7 +16,8 @@ def configure_logger():  # pragma: no cover
     log_file_path = os.getenv("LOGFILE_PATH",
                               "/home/etdadm/logs/etd_dash")
     formatter = logging.Formatter(
-                '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+                '%(asctime)s - %(name)s - %(levelname)s - ' +
+                '[%(filename)s:%(funcName)s:%(lineno)d] - %(message)s')
 
     console_handler = logging.StreamHandler()
     console_handler.setFormatter(formatter)

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -125,6 +125,7 @@ def send_to_dash(json_message):
             return new_message
 
         current_span.add_event("to next queue")  # pragma: no cover, unit tests end before this span # noqa: E501
+        logger.debug("to next queue")
         app.send_task("etd-alma-service.tasks.send_to_alma",
                       args=[new_message], kwargs={},
                       queue=os.getenv('PUBLISH_QUEUE_NAME'))  # pragma: no cover, unit tests should not progress the message # noqa: E501

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -125,7 +125,7 @@ def send_to_dash(json_message):
             return new_message
 
         current_span.add_event("to next queue")  # pragma: no cover, unit tests end before this span # noqa: E501
-        logger.debug("to next queue")
+        logger.debug("to next queue") # pragma: no cover, unit tests end before this span # noqa: E501
         app.send_task("etd-alma-service.tasks.send_to_alma",
                       args=[new_message], kwargs={},
                       queue=os.getenv('PUBLISH_QUEUE_NAME'))  # pragma: no cover, unit tests should not progress the message # noqa: E501

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -125,7 +125,7 @@ def send_to_dash(json_message):
             return new_message
 
         current_span.add_event("to next queue")  # pragma: no cover, unit tests end before this span # noqa: E501
-        logger.debug("to next queue") # pragma: no cover, unit tests end before this span # noqa: E501
+        logger.debug("to next queue")  # pragma: no cover, unit tests end before this span # noqa: E501
         app.send_task("etd-alma-service.tasks.send_to_alma",
                       args=[new_message], kwargs={},
                       queue=os.getenv('PUBLISH_QUEUE_NAME'))  # pragma: no cover, unit tests should not progress the message # noqa: E501


### PR DESCRIPTION
** Prepare logging for production**
* * *

**JIRA Ticket**: https://at-harvard.atlassian.net/browse/ETD-281


# What does this Pull Request do?
adds filename and line number info to logs

# How should this be tested?
## Local setup
    
1. Make a copy of the .env.example to .env and modify the user and password variables.

2. Start the container
    
```
docker-compose -f docker-compose-local.yml up -d --build --force-recreate
```

3. Exec into the container:

```
docker exec -it etd-base-template bash
```

4. Run the tests

```
pytest
```

4. check the logs:
```
tail -f ~/logs/etd/<CONTAINER_ID>_console_<TIMESTAMP>.log
```

if you see output similar to this:
```
2023-12-14 22:55:29,911 - etd_dash - INFO - [tasks.py:send_to_dash:89] - message
2023-12-14 22:55:29,913 - etd_dash - INFO - [tasks.py:send_to_dash:90] - {'job_ticket_id': 'test_ticket_id', 'unit_test': 'true', 'feature_flags': {'dash_feature_flag': 'off', 'alma_feature_flag': 'off', 'send_to_drs_feature_flag': 'off', 'drs_holding_record_feature_flag': 'off'}, 'identifier': '30522803'}
2023-12-14 22:55:29,914 - etd_dash - DEBUG - [tasks.py:send_to_dash:117] - FEATURE FLAGS FOUND
2023-12-14 22:55:29,915 - etd_dash - DEBUG - [tasks.py:send_to_dash:118] - {'dash_feature_flag': 'off', 'alma_feature_flag': 'off', 'send_to_drs_feature_flag': 'off', 'drs_holding_record_feature_flag': 'off'}
2023-12-14 22:55:29,925 - etd_dash - DEBUG - [worker.py:call_api:713] - In call api
2023-12-14 22:55:29,925 - etd_dash - DEBUG - [worker.py:call_api:714] - REST api is running.
2023-12-14 22:55:29,932 - etd_dash - DEBUG - [worker.py:call_api:713] - In call api
2023-12-14 22:55:29,933 - etd_dash - DEBUG - [worker.py:call_api:714] - REST api is running.
2023-12-14 22:55:29,944 - etd_dash - INFO - [worker.py:rewrite_mets:525] - proquest id: 30522803
2023-12-14 22:55:29,944 - etd_dash - INFO - [worker.py:rewrite_mets:505] - 'qualifier'
2023-12-14 22:55:29,947 - etd_dash - INFO - [worker.py:rewrite_mets:505] - 'qualifier'
2023-12-14 22:55:29,949 - etd_dash - INFO - [worker.py:rewrite_mets:505] - 'qualifier'
2023-12-14 22:55:29,950 - etd_dash - INFO - [worker.py:rewrite_mets:505] - 'qualifier'
2023-12-14 22:55:29,952 - etd_dash - INFO - [worker.py:rewrite_mets:505] - 'qualifier'
2023-12-14 22:55:29,953 - etd_dash - INFO - [worker.py:rewrite_mets:668] - 'start-date'
2023-12-14 22:55:29,955 - etd_dash - INFO - [worker.py:rewrite_mets:668] - 'start-date'
2023-12-14 22:55:29,956 - etd_dash - INFO - [worker.py:rewrite_mets:668] - 'start-date'
2023-12-14 22:55:29,965 - etd_dash - DEBUG - [worker.py:check_for_duplicates:723] - URL: https://dash.harvard.edu/rest/items/find-by-metadata-field
```
then the test was successful.


# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? n
- integration tests? n

# Interested parties
Tag (@ mention) interested parties: @awoods 
