### PR TITLE
remove no cover from def sh

### DIFF
--- a/etd/worker.py
+++ b/etd/worker.py
@@ -663,7 +663,7 @@ class Worker():
         current_span.add_event("rewrite mets completed")
         return sendToDash
 
-    def sh(self, *args, **kwargs):  # pragma: no cover
+    def sh(self, *args, **kwargs):
         kwargs['stdout'] = kwargs['stderr'] = PIPE
         return run(*args, **kwargs)
 


### PR DESCRIPTION
**Remove no coverage comment from 'sh' function**
* * *

**JIRA Ticket**: [(link)](https://at-harvard.atlassian.net/browse/ETD-266)

# What does this Pull Request do?
By removing no coverage comment from 'sh' function, and still seeing 100% coverage, we know that method is fully covered

# How should this be tested?

A description of what steps someone could take to:
- Check out this branch from github
- Start up local docker: > docker-compose -f docker-compose-local.yml up --build -d --force-recreate
- exec into docker: docker exec -it etd-dash-service bash
- run coverage, should show 100%
- - python -m coverage run -p -m pytest
-- python -m coverage combine
-- python -m coverage report -m --skip-covered

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests?
- integration tests?

# Interested parties
Tag (@ mention) interested parties
