### PR TITLE
Archive duplicate submissions to dupe directory on dropbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,6 @@ cython_debug/
 /.pydevproject
 tests/data/in/proquest2023071720-993578-gsd/mets.xml
 coverage.json
+
+# vscode
+.local

--- a/etd/worker.py
+++ b/etd/worker.py
@@ -749,7 +749,13 @@ class Worker():
 
             # create dupe directory if needed
             if not xfer.isdir(f'dupe/{schoolCode}'):
-                xfer.makedirs(f'dupe/{schoolCode}')
+                try:
+                    xfer.makedirs(f'dupe/{schoolCode}')
+                except Exception as e:
+                    log_msg = f'Failed to create dupe/{schoolCode}: {e}'
+                    notifyJM.log('fail', log_msg)
+                    self.logger.error(log_msg)
+                    return
 
             # move the file to the dupe directory
             dupe_file = schoolFile.replace(".",

--- a/etd/worker.py
+++ b/etd/worker.py
@@ -413,8 +413,6 @@ class Worker():
                         continue
 
                     try:
-                        xfer.rename(f'incoming/{schoolCode}/{schoolFile}',
-                                    f'archives/{schoolCode}/{schoolFile}')
                         self.move_to_archives_dir(xfer, schoolCode, schoolFile,
                                                   dropboxServer, notifyJM)
                     except Exception as e:
@@ -749,13 +747,7 @@ class Worker():
 
             # create dupe directory if needed
             if not xfer.isdir(f'dupe/{schoolCode}'):
-                try:
-                    xfer.makedirs(f'dupe/{schoolCode}')
-                except Exception as e:
-                    log_msg = f'Failed to create dupe/{schoolCode}: {e}'
-                    notifyJM.log('fail', log_msg)
-                    self.logger.error(log_msg)
-                    return
+                xfer.makedirs(f'dupe/{schoolCode}')
 
             # move the file to the dupe directory
             dupe_file = schoolFile.replace(".",

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -394,4 +394,4 @@ class TestWorkerClass():
 
         assert xfer.exists
         assert info_logs == [expected_info_log, expected_info_log_dupe]
-        assert warn_logs == [expected_warn_log]            
+        assert warn_logs == [expected_warn_log]

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -5,6 +5,7 @@ import shutil
 import lxml.etree as ET
 import os
 import glob
+from lib.notify import notify
 
 
 class MockResponse:
@@ -17,6 +18,31 @@ class MockDuplicateResponse:
 
 class MockNoDuplicateResponse:
     text = '[]'
+
+
+class MockXfer:
+    def __init__(self, exists=True):
+        self.exists = exists
+
+    def rename(self, src, dest):
+        pass
+
+    def isfile(self, path):
+        return self.exists
+
+    def isdir(self, path):
+        pass
+
+    def makedirs(self, path):
+        pass
+
+
+class MockLogger:
+    def info(self, msg):
+        pass  # pragma: no cover
+
+    def warn(self, msg):
+        pass  # pragma: no cover
 
 
 # create a directory if it does not exist
@@ -295,3 +321,77 @@ class TestWorkerClass():
         # cleanup outDir and files
         if os.path.exists(outDir):
             shutil.rmtree(outDir)
+
+    def test_move_to_archives_dir_file_not_exists(self, monkeypatch):
+        worker = Worker()
+        xfer = MockXfer(exists=False)
+        notifyJM = notify('monitor', 'proquest2dash_test', None)
+        monkeypatch.setattr(worker, "logger", MockLogger())
+        monkeypatch.setattr(worker, "get_timestamp", lambda: "timestamp")
+
+        schoolCode = "gsd"
+        schoolFile = "submission_993578.zip"
+        dropboxServer = "dropbox_server"
+
+        archives_path = f"archives/{schoolCode}/{schoolFile}"
+
+        expected_info_log = f"Moving {schoolFile} to {archives_path}"
+
+        info_logs = []
+        warn_logs = []
+
+        def mock_info_log(msg):
+            info_logs.append(msg)
+
+        def mock_warn_log(msg):
+            warn_logs.append(msg)  # pragma: no cover
+
+        monkeypatch.setattr(worker.logger, "info", mock_info_log)
+        monkeypatch.setattr(worker.logger, "warn", mock_warn_log)
+
+        worker.move_to_archives_dir(xfer, schoolCode, schoolFile,
+                                    dropboxServer, notifyJM)
+
+        assert not xfer.exists
+        assert info_logs == [expected_info_log]
+        assert warn_logs == []
+
+    def test_move_to_archives_dir_file_exists(self, monkeypatch):
+        worker = Worker()
+        xfer = MockXfer(exists=True)
+        notifyJM = notify('monitor', 'proquest2dash_test', None)
+        monkeypatch.setattr(worker, "logger", MockLogger())
+        monkeypatch.setattr(worker, "get_timestamp", lambda: "timestamp")
+
+        schoolCode = "gsd"
+        schoolFile = "submission_993578.zip"
+        dropboxServer = "dropbox_server"
+
+        archives_path = f"archives/{schoolCode}/{schoolFile}"
+        expected_dupe_file = schoolFile.replace(".", "_timestamp.")
+        expected_dupe_path = f"dupe/{schoolCode}/{expected_dupe_file}"
+
+        expected_info_log = f"Moving {schoolFile} to {archives_path}"
+        expected_warn_log = (
+            f"File {schoolFile} already exists in {archives_path}."
+        )
+        expected_info_log_dupe = f"Moving {schoolFile} to {expected_dupe_path}"
+
+        info_logs = []
+        warn_logs = []
+
+        def mock_info_log(msg):
+            info_logs.append(msg)
+
+        def mock_warn_log(msg):
+            warn_logs.append(msg)
+
+        monkeypatch.setattr(worker.logger, "info", mock_info_log)
+        monkeypatch.setattr(worker.logger, "warn", mock_warn_log)
+
+        worker.move_to_archives_dir(xfer, schoolCode, schoolFile,
+                                    dropboxServer, notifyJM)
+
+        assert xfer.exists
+        assert info_logs == [expected_info_log, expected_info_log_dupe]
+        assert warn_logs == [expected_warn_log]            


### PR DESCRIPTION
**Move duplicate submissions that have already been archived to the dupe directory.**
* * *

**JIRA Ticket**: [ETD-351](https://at-harvard.atlassian.net/browse/ETD-351)

# What does this Pull Request do?
When archiving an ETD submitted in the dropbox, if the ETD is a duplicate that has already been archived, the ETD will be copied to the `dupe/` dir. The submission base name will have a timestamp appended for uniqueness. If the submission were sent through another time, another copy would be made in the `dupe/` dir.

For example, from the dev environment, an archived submission:
> -bash-4.2$ hostname
hegel.lib.harvard.edu
-bash-4.2$ ll -t `find archives/ -type f` | more
-rw-r--r-- 1 proquest guestftp  12999084 Dec 20 09:53 archives/gsd/submission_8197364076.zip

And a duplicate, that was submitted slightly after:
> -bash-4.2$ ll -t `find dupe/ -type f` | more
> -rw-r--r-- 1 proquest guestftp 12999084 Dec 20 09:54 dupe/gsd/submission_8197364076_20231220145403.zip


# How should this be tested?
- Build, deploy, and run pytest locally (according to README.md.)
- The trial branch for this is running in dev. Verify that duplicate directory contents reference previously archived submissions (using commands above).

# Test coverage
Yes/No: Yes
- unit tests? Yes
- integration tests? Coming in a separate PR.

# Interested parties
@michael-lts, @ives1227 
