### PR TITLE
Fix mapfile not found error

### DIFF
--- a/etd/worker.py
+++ b/etd/worker.py
@@ -220,6 +220,19 @@ class Worker():
 
             # Import to DASH
             sub2handle = {}  # we keep mapfile as an on-disk record
+            # check that proquestOutDir exists and log contents
+            if not os.path.isdir(proquestOutDir):
+                notifyJM.log('fail', f'{proquestOutDir} does not exist')
+                self.logger.error(f'{proquestOutDir} does not exist')
+                current_span.add_event(f'{proquestOutDir} does not exist')
+                continue
+            else:
+                notifyJM.log('info', f'{proquestOutDir} exists')
+                self.logger.info(f'{proquestOutDir} exists')
+                current_span.add_event(f'{proquestOutDir} exists')
+                for file in os.listdir(proquestOutDir):
+                    self.logger.info(f'file: {file}')
+
             with open(os.path.join(proquestOutDir,
                                    "mapfile"), 'w') as mapfile:
 

--- a/etd/worker.py
+++ b/etd/worker.py
@@ -190,7 +190,8 @@ class Worker():
                 except Exception as e:
                     self.logger.error(f'Failed to remove \
                                         {proquestOutDir}: {e}')
-                    continue
+                continue
+
             collection_handle = instance_data[schoolCode]['handle']
             dashImportFile = f'{self.dspaceImportDir}/proquest/' + aipFile
 
@@ -220,18 +221,12 @@ class Worker():
 
             # Import to DASH
             sub2handle = {}  # we keep mapfile as an on-disk record
-            # check that proquestOutDir exists and log contents
+            # check that proquestOutDir exists
             if not os.path.isdir(proquestOutDir):
                 notifyJM.log('fail', f'{proquestOutDir} does not exist')
                 self.logger.error(f'{proquestOutDir} does not exist')
                 current_span.add_event(f'{proquestOutDir} does not exist')
                 continue
-            else:
-                notifyJM.log('info', f'{proquestOutDir} exists')
-                self.logger.info(f'{proquestOutDir} exists')
-                current_span.add_event(f'{proquestOutDir} exists')
-                for file in os.listdir(proquestOutDir):
-                    self.logger.info(f'file: {file}')
 
             with open(os.path.join(proquestOutDir,
                                    "mapfile"), 'w') as mapfile:


### PR DESCRIPTION
**Fix mapfile not found error.**
* * *

**JIRA Ticket**: [ETD-358](https://at-harvard.atlassian.net/browse/ETD-358)

# What does this Pull Request do?
The error was being thrown because after a duplicate was detected, it continued to be processed, throwing an error downstream when the mapfile was being accessed. The output directory would not exist. This PR fixes that by immediately moving to the next submission after a duplicated is detected and handed. No attempt is made to access the mapfile for a duplicate. The technical fix was to move the `continue` statement to the correct block.

An additional check was added before the mapfile is accessed to ensure that the output directory exists, in case any other output directory error occurs.

# How should this be tested?
- Visually
- Deploy trial branch and ensure no errors are thrown (note: the trial branch has been deployed and shown to not throw the error).

# Test coverage
Yes/No: Yes
- unit tests? No
- integration tests? Yes, this fixes an existing integration test.

# Interested parties
@ives1227, @michael-lts, @cgoines 
