### PR TITLE
Fix for creating empty mapfile for non DASH submissions

### DIFF
--- a/etd/worker.py
+++ b/etd/worker.py
@@ -132,17 +132,6 @@ class Worker():
             # Rewrite mets file remapping a few elements
             sendToDash = self.rewrite_mets(aipDir, batch, schoolCode, message)
 
-            # Skip the record entirely if we're not sending to dash
-            # Logic for non-DASH records needs to be implemented
-            # if not sendToDash:
-            #     notifyJM.log('info',
-            #                  f"Skipping non-DASH record {aipDir}/{aipFile}")
-            #     current_span.add_event(
-            #         f"Skipping non-DASH record {aipDir}/{aipFile}")
-            #     self.logger.info(
-            #         f"Skipping non-DASH record {aipDir}/{aipFile}")
-            #     continue
-
             # get proquest identifier from json message
             identifier = None
             if "identifier" in message:

--- a/etd/worker.py
+++ b/etd/worker.py
@@ -134,14 +134,14 @@ class Worker():
 
             # Skip the record entirely if we're not sending to dash
             # Logic for non-DASH records needs to be implemented
-            if not sendToDash:
-                notifyJM.log('info',
-                             f"Skipping non-DASH record {aipDir}/{aipFile}")
-                current_span.add_event(
-                    f"Skipping non-DASH record {aipDir}/{aipFile}")
-                self.logger.info(
-                    f"Skipping non-DASH record {aipDir}/{aipFile}")
-                continue
+            # if not sendToDash:
+            #     notifyJM.log('info',
+            #                  f"Skipping non-DASH record {aipDir}/{aipFile}")
+            #     current_span.add_event(
+            #         f"Skipping non-DASH record {aipDir}/{aipFile}")
+            #     self.logger.info(
+            #         f"Skipping non-DASH record {aipDir}/{aipFile}")
+            #     continue
 
             # get proquest identifier from json message
             identifier = None
@@ -184,6 +184,12 @@ class Worker():
 
             # Not sending to dash, print and empty mapfile
             if not sendToDash:
+                notifyJM.log('info',
+                             f"Skipping non-DASH record {aipDir}/{aipFile}")
+                current_span.add_event(
+                    f"Skipping non-DASH record {aipDir}/{aipFile}")
+                self.logger.info(
+                    f"Skipping non-DASH record {aipDir}/{aipFile}")
                 open(os.path.join(proquestOutDir, "mapfile"), 'w').close()
                 continue
 


### PR DESCRIPTION
**Creates an empty mapfile for nonDASH submissions**
* * *

**JIRA Ticket**: https://at-harvard.atlassian.net/browse/ETD-360

# How should this be tested?

Submit a sample nonDASH submission via the integration test: https://ltsds-cloud-dev-1.lib.harvard.edu:10610/etd_end_to_end_no_dash and verify that an empty mapfile has been created (done)

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? no
- integration tests? no

