### PR TITLE
parse log backup count to int, add logging for no files found

### DIFF
--- a/etd/__init__.py
+++ b/etd/__init__.py
@@ -4,7 +4,7 @@ import os
 import socket
 from datetime import datetime
 
-LOG_FILE_BACKUP_COUNT = os.getenv('LOG_FILE_BACKUP_COUNT')
+LOG_FILE_BACKUP_COUNT = int(os.getenv('LOG_FILE_BACKUP_COUNT', '30'))
 LOG_ROTATION = "midnight"
 
 container_id = socket.gethostname()

--- a/etd/worker.py
+++ b/etd/worker.py
@@ -90,6 +90,7 @@ class Worker():
 
         aipFiles = self.get_files()
         if not aipFiles:
+            self.logger.info('No files found in dropbox')
             notifyJM.log('pass', 'No files found in dropbox')
             notifyJM.report('complete')
             return True


### PR DESCRIPTION
**Fix logging parse error.**
* * *

**JIRA Ticket**: [(link)](https://at-harvard.atlassian.net/browse/ETD-396)

# What does this Pull Request do?
This pr fixes error in pulling backupCount from the env file, needs to be parsed to int. (seems to happen sporadically for some reason, never determined why it doesn't always fail). Also, adds logging line for when nothing found in dropbox (was previously only logging this to jobmon).
I attempted to test rollover at the daily level, other than midnight, but this is a different syntax than default midnight. We should not need the datestamp in the file, as daily the log should roll and append timestamp. Since the worst is redundancy, and since we will be moving away from file-based logging in k8s, I chose to leave datestamp and not test further.

# How should this be tested?

Confirm local test run, for regression test.
- docker-compose -f docker-compose-local.yml up --build -d --force-recreate
- docker exec -it etd-dash-service bash
- - pytest
Deploy to dev and confirm docker comes up without error. Confirm jenkins itest logs to file and appends when a 2nd itest is run (all of this has already been done

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests?
- integration tests?

# Interested parties
Tag (@ mention) interested parties
