### PR TITLE
Etd 400

### DIFF
--- a/etd/worker.py
+++ b/etd/worker.py
@@ -493,16 +493,16 @@ class Worker():
         # Find and remapped fields
         for dimField in rootMets.iter(f'{self.dimNamespace}field'):
             if dimField.attrib['mdschema'] == 'dc':
-                if dimField.attrib['element'] == 'date':
-                    if dimField.attrib['qualifier'] == 'created':
-                        dimField.attrib['mdschema'] = 'thesis'
-                        dimField.attrib['element'] = 'degree'
-                        dimField.attrib['qualifier'] = 'date'
+                #if dimField.attrib['element'] == 'date':
+                #    if dimField.attrib['qualifier'] == 'created':
+                #        dimField.attrib['mdschema'] = 'thesis'
+                #        dimField.attrib['element'] = 'degree'
+                #        dimField.attrib['qualifier'] = 'date'
+                #
+                #     elif dimField.attrib['qualifier'] == 'submitted':
+                #        dimField.attrib['qualifier'] = 'created'
 
-                    elif dimField.attrib['qualifier'] == 'submitted':
-                        dimField.attrib['qualifier'] = 'created'
-
-                elif dimField.attrib['element'] == 'subject':
+                if dimField.attrib['element'] == 'subject':
                     # if dimField.attrib['qualifier'] exists, and it's PQ,
                     # remove it
                     if 'qualifier' in dimField.attrib and \
@@ -534,12 +534,12 @@ class Worker():
 
             elif dimField.attrib['mdschema'] == 'thesis':
                 if dimField.attrib['element'] == 'degree':
-                    if dimField.attrib['qualifier'] == 'date':
-                        dimField.attrib['mdschema'] = 'dc'
-                        dimField.attrib['element'] = 'date'
-                        dimField.attrib['qualifier'] = 'submitted'
+                    # if dimField.attrib['qualifier'] == 'date':
+                    #    dimField.attrib['mdschema'] = 'dc'
+                    #    dimField.attrib['element'] = 'date'
+                    #    dimField.attrib['qualifier'] = 'submitted'
 
-                    elif dimField.attrib['qualifier'] == 'name':
+                    if dimField.attrib['qualifier'] == 'name':
 
                         # College Undergraduate	and DCE Masters
                         if (dimField.text == 'A.B.' or dimField.text == 'S.B.'

--- a/etd/worker.py
+++ b/etd/worker.py
@@ -493,14 +493,6 @@ class Worker():
         # Find and remapped fields
         for dimField in rootMets.iter(f'{self.dimNamespace}field'):
             if dimField.attrib['mdschema'] == 'dc':
-                #if dimField.attrib['element'] == 'date':
-                #    if dimField.attrib['qualifier'] == 'created':
-                #        dimField.attrib['mdschema'] = 'thesis'
-                #        dimField.attrib['element'] = 'degree'
-                #        dimField.attrib['qualifier'] = 'date'
-                #
-                #     elif dimField.attrib['qualifier'] == 'submitted':
-                #        dimField.attrib['qualifier'] = 'created'
 
                 if dimField.attrib['element'] == 'subject':
                     # if dimField.attrib['qualifier'] exists, and it's PQ,
@@ -534,10 +526,6 @@ class Worker():
 
             elif dimField.attrib['mdschema'] == 'thesis':
                 if dimField.attrib['element'] == 'degree':
-                    # if dimField.attrib['qualifier'] == 'date':
-                    #    dimField.attrib['mdschema'] = 'dc'
-                    #    dimField.attrib['element'] = 'date'
-                    #    dimField.attrib['qualifier'] = 'submitted'
 
                     if dimField.attrib['qualifier'] == 'name':
 

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -151,13 +151,13 @@ class TestWorkerClass():
 
         assert doc.xpath("//dim:field[text()='2023-05']",
                          namespaces=namespace_mapping)[0].\
-            get('element') == "date"
+            get('element') == "degree"
         assert doc.xpath("//dim:field[text()='2023-05']",
                          namespaces=namespace_mapping)[0].\
-            get('mdschema') == "dc"
+            get('mdschema') == "thesis"
         assert doc.xpath("//dim:field[text()='2023-05']",
                          namespaces=namespace_mapping)[0].\
-            get('qualifier') == "submitted"
+            get('qualifier') == "date"
 
         assert doc.xpath("//dim:field[@qualifier='level']",
                          namespaces=namespace_mapping)[0].\


### PR DESCRIPTION
**Leave dates unmapped.**
* * *

**JIRA Ticket**: [(link)](https://at-harvard.atlassian.net/browse/ETD-400)

# What does this Pull Request do?
Original specs for the legacy etd dash app called for mapping 3 mets dates field to different date fields. This caused issues with how alma dates showed up. Colin has confirmed we can remove those 3 mappings and keep the mets dates as received from PQ; this is ok for dash as well as alma

# How should this be tested?

- Check out this branch (ETD-400)
- docker-compose -f docker-compose-local.yml up --build -d --force-recreate
- docker exec -it etd-dash-service bash 
- pytest (tests should pass)

- deploy as a trial branch to dev (done)
- submit a package to confirm dates are mapped as expected (done, tested by Paul)

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? Y
- integration tests?

# Interested parties
Tag (@ mention) interested parties
